### PR TITLE
hotfix statdir

### DIFF
--- a/internal/stat/collect.go
+++ b/internal/stat/collect.go
@@ -2,9 +2,7 @@ package stat
 
 import (
 	"fmt"
-	"log"
 	"math/rand"
-	"net/netip"
 	"os"
 	"path/filepath"
 	"time"
@@ -13,22 +11,7 @@ import (
 	"github.com/vpngen/keydesk/keydesk/storage"
 )
 
-func CollectingData(kill <-chan struct{}, addr netip.AddrPort, rdata bool, brigadeID, dbDir, statsDir string) {
-	db := &storage.BrigadeStorage{
-		BrigadeID:       brigadeID,
-		BrigadeFilename: filepath.Join(dbDir, storage.BrigadeFilename),
-		BrigadeSpinlock: filepath.Join(dbDir, storage.BrigadeSpinlockFilename),
-		APIAddrPort:     addr,
-		BrigadeStorageOpts: storage.BrigadeStorageOpts{
-			MaxUsers:               keydesk.MaxUsers,
-			MonthlyQuotaRemaining:  keydesk.MonthlyQuotaRemaining,
-			MaxUserInctivityPeriod: keydesk.DefaultMaxUserInactivityPeriod,
-		},
-	}
-	if err := db.SelfCheckAndInit(); err != nil {
-		log.Fatalf("Storage initialization: %s\n", err)
-	}
-
+func CollectingData(db *storage.BrigadeStorage, kill <-chan struct{}, rdata bool, statsDir string) {
 	statsFilename := filepath.Join(statsDir, storage.StatsFilename)
 	statsSpinlock := filepath.Join(statsDir, storage.StatsSpinlockFilename)
 
@@ -40,7 +23,7 @@ func CollectingData(kill <-chan struct{}, addr netip.AddrPort, rdata bool, briga
 	for {
 		select {
 		case ts := <-timer.C:
-			_, _ = fmt.Fprintf(os.Stdout, "%s: Collecting data: %s: %s\n", ts.UTC().Format(time.RFC3339), brigadeID, statsFilename)
+			_, _ = fmt.Fprintf(os.Stdout, "%s: Collecting data: %s: %s\n", ts.UTC().Format(time.RFC3339), db.BrigadeID, statsFilename)
 
 			if err := db.GetStats(rdata, statsFilename, statsSpinlock, keydesk.DefaultEndpointsTTL); err != nil {
 				_, _ = fmt.Fprintf(os.Stdout, "Error collecting stats: %s\n", err)


### PR DESCRIPTION
- moved `-s` flag to `parseArgs()`
- if `-s` is not provided, use default value
- return statDir from parseArgs()
- pass *StorageBrigade to `stat.CollectingData` instead of creating duplicate